### PR TITLE
make use of ensure_packages

### DIFF
--- a/manifests/dependencies.pp
+++ b/manifests/dependencies.pp
@@ -15,8 +15,5 @@
 #
 class download_uncompress::dependencies {
   $enhancers = ['unzip']
-
-  package { $enhancers:
-    ensure => installed,
-  }
+  ensure_packages($enhancers)
 }


### PR DESCRIPTION
prevents failures when other modules already have a dependency on Package['unzip']

Would be great if you could merge it and release it as soon as possible :)
